### PR TITLE
removing buggy ext=1 call to fill_halos_vctr_alng in FCT 2D/3D 

### DIFF
--- a/libmpdata++/solvers/detail/mpdata_fct_2d.hpp
+++ b/libmpdata++/solvers/detail/mpdata_fct_2d.hpp
@@ -55,7 +55,7 @@ namespace libmpdataxx
 	  const auto &im(this->im), &jm(this->jm); // calculating once for (i/j)-1/2 and (i/j)+1/2
 
 	  // fill halos of GC_corr -> mpdata works with halo=1, we need halo=2
-          this->xchng_vctr_alng(GC_corr, 1); // TODO: double check if ext=1 needed
+          this->xchng_vctr_alng(GC_corr);
 
           // calculation of fluxes for betas denominators
           if (opts::isset(ct_params_t::opts, opts::iga))

--- a/libmpdata++/solvers/detail/mpdata_fct_3d.hpp
+++ b/libmpdata++/solvers/detail/mpdata_fct_3d.hpp
@@ -68,7 +68,7 @@ namespace libmpdataxx
             im1 = this->im^1, jm1 = this->jm^1, km1 = this->km^1; 
 
 	  // fill halos -> mpdata works with halo=1, we need halo=2
-          this->xchng_vctr_alng(GC_corr, 1); // TODO: double check
+          this->xchng_vctr_alng(GC_corr);
           
           // calculation of fluxes for betas denominators
           if (opts::isset(ct_params_t::opts, opts::iga))

--- a/libmpdata++/solvers/detail/solver_2d.hpp
+++ b/libmpdata++/solvers/detail/solver_2d.hpp
@@ -47,13 +47,13 @@ namespace libmpdataxx
           this->xchng_sclr(this->mem->psi[e][ this->n[e]], i^this->halo, j^this->halo);
 	}
 
-        virtual void xchng_vctr_alng(const arrvec_t<typename parent_t::arr_t> &arrvec, int ext = 0) final
+        virtual void xchng_vctr_alng(const arrvec_t<typename parent_t::arr_t> &arrvec) final
         {
           this->mem->barrier();
-          bcxl->fill_halos_vctr_alng(arrvec, j^ext);
-          bcxr->fill_halos_vctr_alng(arrvec, j^ext);
-          bcyl->fill_halos_vctr_alng(arrvec, i^ext);
-          bcyr->fill_halos_vctr_alng(arrvec, i^ext);
+          bcxl->fill_halos_vctr_alng(arrvec, j);
+          bcxr->fill_halos_vctr_alng(arrvec, j);
+          bcyl->fill_halos_vctr_alng(arrvec, i);
+          bcyr->fill_halos_vctr_alng(arrvec, i);
           // TODO: open bc nust be last!!!
           this->mem->barrier();
         }

--- a/libmpdata++/solvers/detail/solver_3d.hpp
+++ b/libmpdata++/solvers/detail/solver_3d.hpp
@@ -50,15 +50,15 @@ namespace libmpdataxx
 	  this->xchng_sclr(this->mem->psi[e][ this->n[e]], i^this->halo, j^this->halo, k^this->halo);
 	}
 
-        void xchng_vctr_alng(const arrvec_t<typename parent_t::arr_t> &arrvec, int ext = 0)
+        void xchng_vctr_alng(const arrvec_t<typename parent_t::arr_t> &arrvec)
         {
           this->mem->barrier();
-          bcxl->fill_halos_vctr_alng(arrvec, j^ext, k^ext); 
-          bcxr->fill_halos_vctr_alng(arrvec, j^ext, k^ext);
-          bcyl->fill_halos_vctr_alng(arrvec, k^ext, i^ext); 
-          bcyr->fill_halos_vctr_alng(arrvec, k^ext, i^ext);
-          bczl->fill_halos_vctr_alng(arrvec, i^ext, j^ext);
-          bczr->fill_halos_vctr_alng(arrvec, i^ext, j^ext);
+          bcxl->fill_halos_vctr_alng(arrvec, j, k); 
+          bcxr->fill_halos_vctr_alng(arrvec, j, k);
+          bcyl->fill_halos_vctr_alng(arrvec, k, i); 
+          bcyr->fill_halos_vctr_alng(arrvec, k, i);
+          bczl->fill_halos_vctr_alng(arrvec, i, j);
+          bczr->fill_halos_vctr_alng(arrvec, i, j);
           this->mem->barrier();
         }
         


### PR DESCRIPTION
it is not needed, as fill_halos_vctr_nrml fills the data, additionally this appears to have caused the bogus behaviour with 1-gridpoint-long columns/slabs (e.g. OMP_NUM_THREADS=30 for revolving sphere)
