### PR TITLE
adding an inter-equation barrier in solver_common - fixes buggy behaviou...

### DIFF
--- a/libmpdata++/solvers/detail/mpdata_fct_common.hpp
+++ b/libmpdata++/solvers/detail/mpdata_fct_common.hpp
@@ -37,11 +37,8 @@ namespace libmpdataxx
 
         void beta_barrier(const int &iter)
         {
-	  if ( 
-	    (iter == this->n_iters - 1 && parent_t::n_eqns > 1) // in the last iteration advop for the next equation will overwrite psi_min/psi_max
-	    ||
-	    (!opts::isset(ct_params_t::opts, opts::iga)) // this->flux would be overwritten by donor-cell
-	  ) this->mem->barrier();
+	  if (!opts::isset(ct_params_t::opts, opts::iga)) // this->flux would be overwritten by donor-cell
+	    this->mem->barrier();
         }
 
         public:

--- a/libmpdata++/solvers/detail/solver_common.hpp
+++ b/libmpdata++/solvers/detail/solver_common.hpp
@@ -177,7 +177,11 @@ namespace libmpdataxx
 	    for (int e = 0; e < n_eqns; ++e) scale(e, ct_params_t::hint_scale(e));
 
 	    for (int e = 0; e < n_eqns; ++e) xchng(e);
-	    for (int e = 0; e < n_eqns; ++e) advop(e);
+	    for (int e = 0; e < n_eqns; ++e) 
+            { 
+              advop(e);
+              if (e != n_eqns - 1) this->mem->barrier();
+            }
 	    for (int e = 0; e < n_eqns; ++e) cycle(e); // note: cycle assumes ascending loop index
 
 	    for (int e = 0; e < n_eqns; ++e) scale(e, -ct_params_t::hint_scale(e));


### PR DESCRIPTION
...r related with overwriting FCT fluxes by donor cell; makes beta_barrier() simpler as well
