### PR TITLE
using --HEAD for blitz installation with homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ install:
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo $apt_get_install cmake; fi
 
     # blitz
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install blitz; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install --HEAD blitz; fi
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo $apt_get_install libblitz0-dev; fi
 
     # hdf5


### PR DESCRIPTION
this will bring along numerous fixes that are available on the Blitz++ github repo (http://github.com/blitzpp/blitz)