### PR TITLE
Adapt for use in multiple translation units

### DIFF
--- a/libmpdata++/formulae/arakawa_c.hpp
+++ b/libmpdata++/formulae/arakawa_c.hpp
@@ -12,7 +12,10 @@ namespace libmpdataxx
 {
   namespace arakawa_c
   {
-    struct hlf_t {} h; 
+    namespace
+    {
+      struct hlf_t {} h; 
+    };
 
     inline rng_t operator+(
       const rng_t &i, const hlf_t &

--- a/libmpdata++/formulae/arakawa_c.hpp
+++ b/libmpdata++/formulae/arakawa_c.hpp
@@ -15,40 +15,40 @@ namespace libmpdataxx
     namespace
     {
       struct hlf_t {} h; 
+
+      rng_t operator+(
+        const rng_t &i, const hlf_t &
+      ) { 
+        return i; 
+      } 
+
+      rng_t operator-(
+        const rng_t &i, const hlf_t &
+      ) { 
+        return i-1; 
+      }
+      
+      int operator+(
+        const int i, const hlf_t &
+      ) { 
+        return i; 
+      } 
+
+      int operator-(
+        const int i, const hlf_t &
+      ) { 
+        return i-1; 
+      }
+
+      template<class n_t>
+      rng_t operator^(
+        const rng_t &r, const n_t &n
+      ) { 
+        return rng_t(
+          (r - n).first(), 
+          (r + n).last()
+        ); 
+      } 
     };
-
-    inline rng_t operator+(
-      const rng_t &i, const hlf_t &
-    ) { 
-      return i; 
-    } 
-
-    inline rng_t operator-(
-      const rng_t &i, const hlf_t &
-    ) { 
-      return i-1; 
-    }
-    
-    inline int operator+(
-      const int i, const hlf_t &
-    ) { 
-      return i; 
-    } 
-
-    inline int operator-(
-      const int i, const hlf_t &
-    ) { 
-      return i-1; 
-    }
-
-    template<class n_t>
-    inline rng_t operator^(
-      const rng_t &r, const n_t &n
-    ) { 
-      return rng_t(
-        (r - n).first(), 
-        (r + n).last()
-      ); 
-    } 
   } // namespace arakawa_c
 } // namespace libmpdataxx

--- a/libmpdata++/formulae/arakawa_c.hpp
+++ b/libmpdata++/formulae/arakawa_c.hpp
@@ -16,32 +16,32 @@ namespace libmpdataxx
     {
       struct hlf_t {} h; 
 
-      rng_t operator+(
+      inline rng_t operator+(
         const rng_t &i, const hlf_t &
       ) { 
         return i; 
       } 
 
-      rng_t operator-(
+      inline rng_t operator-(
         const rng_t &i, const hlf_t &
       ) { 
         return i-1; 
       }
       
-      int operator+(
+      inline int operator+(
         const int i, const hlf_t &
       ) { 
         return i; 
       } 
 
-      int operator-(
+      inline int operator-(
         const int i, const hlf_t &
       ) { 
         return i-1; 
       }
 
       template<class n_t>
-      rng_t operator^(
+      inline rng_t operator^(
         const rng_t &r, const n_t &n
       ) { 
         return rng_t(

--- a/libmpdata++/opts.hpp
+++ b/libmpdata++/opts.hpp
@@ -63,7 +63,7 @@ namespace libmpdataxx
       {fot, "fot"}
     };
 
-    std::string opts_string(opts_t opts)
+    inline std::string opts_string(opts_t opts)
     {
       std::string ret;
       const auto opt_order = {nug, iga, abs, dfl, div_2nd, tot, div_3rd, fot, fct, pfc, npa, khn};

--- a/libmpdata++/output/detail/xdmf_writer.hpp
+++ b/libmpdata++/output/detail/xdmf_writer.hpp
@@ -30,8 +30,8 @@ namespace libmpdataxx
         struct data_item
         {
           blitz::TinyVector<int, dim> dimensions;
-          static const std::string number_type;
-          static const std::string format;
+          const std::string number_type = "Float";
+          const std::string format = "HDF";
           std::string data;
           void add(ptree& node)
           {
@@ -47,7 +47,7 @@ namespace libmpdataxx
 
         struct topology
         {
-          static const std::string topology_type;
+          const std::string topology_type = dim == 2 ? "2DSMesh" : "3DSMesh";
           blitz::TinyVector<int, dim> dimensions;
           void add(ptree& node)
           {
@@ -61,7 +61,7 @@ namespace libmpdataxx
 
         struct geometry
         {
-          static const std::string geometry_type;
+          const std::string geometry_type = dim == 2 ? "X_Y" : "X_Y_Z";
           std::array<data_item, dim> coords;
           void add(ptree& node)
           {
@@ -75,8 +75,8 @@ namespace libmpdataxx
         struct attribute
         {
           std::string name;
-          static const std::string attribute_type;
-          static const std::string center;
+          const std::string attribute_type = "Scalar";
+          const std::string center = "Cell";
           mutable data_item item;
           void add(ptree& node)
           {
@@ -94,8 +94,8 @@ namespace libmpdataxx
           }
         };
 
-        static const std::string name;
-        static const std::string grid_type;
+        const std::string name = "Grid";
+        const std::string grid_type = "Uniform";
         topology top;
         geometry geo;
         std::set<attribute> attrs;
@@ -202,27 +202,6 @@ namespace libmpdataxx
 
       };
 
-      // compile time constants
-      template<int dim>
-      const std::string xdmf_writer<dim>::data_item::number_type = "Float";
-      template<int dim>
-      const std::string xdmf_writer<dim>::data_item::format = "HDF";
-      template<>
-      const std::string xdmf_writer<3>::topology::topology_type = "3DSMesh";
-      template<>
-      const std::string xdmf_writer<2>::topology::topology_type = "2DSMesh";
-      template<>
-      const std::string xdmf_writer<3>::geometry::geometry_type = "X_Y_Z";
-      template<>
-      const std::string xdmf_writer<2>::geometry::geometry_type = "X_Y";
-      template<int dim>
-      const std::string xdmf_writer<dim>::attribute::attribute_type = "Scalar";
-      template<int dim>
-      const std::string xdmf_writer<dim>::attribute::center = "Cell";
-      template<int dim>
-      const std::string xdmf_writer<dim>::name = "Grid";
-      template<int dim>
-      const std::string xdmf_writer<dim>::grid_type = "Uniform";
     }
   }
 }

--- a/libmpdata++/solvers/detail/monitor.hpp
+++ b/libmpdata++/solvers/detail/monitor.hpp
@@ -16,7 +16,7 @@ namespace libmpdataxx
   {
     namespace detail
     {
-      void monitor(float frac)
+      inline void monitor(float frac)
       {
 	char name[17];
 #if defined(__linux__)


### PR DESCRIPTION
I'm trying to speedup compilation of UWLCM by dividing it into multiple translation units, that can be compiled in parallel. To do that, some changes in libmpdata++ are required.