### PR TITLE
prs solvers laplacian calc (with err_init): move set_edges before G m…

### DIFF
--- a/libmpdata++/solvers/detail/mpdata_rhs_vip_prs_common.hpp
+++ b/libmpdata++/solvers/detail/mpdata_rhs_vip_prs_common.hpp
@@ -63,6 +63,7 @@ namespace libmpdataxx
               lap_tmp[d](this->ijk) -= tmp_uvw[d](this->ijk);
             }
           }
+          this->set_edges(lap_tmp, this->ijk, err_init ? -1 : 0);
           if (this->mem->G)
           {
             for (int d = 0; d < parent_t::n_dims; ++d)
@@ -71,7 +72,6 @@ namespace libmpdataxx
             }
           }
           if (!simple) this->normalize_vip(lap_tmp);
-          this->set_edges(lap_tmp, this->ijk, err_init ? -1 : 0);
           for (int d = 0; d < parent_t::n_dims; ++d)
           {
             this->xchng_pres(lap_tmp[d], ijk);


### PR DESCRIPTION
…ultiplication (but also before normalize_vip...) - fixes open bconds with nonzero initial velocity